### PR TITLE
Honour configured EJBCA connect and request timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ EJBCA NG `Connector` is provided as a Docker container. Use the `docker pull cze
 | `REMOTE_DEBUG`           | Enables JVM remote debug on port 5005                  | ![](https://img.shields.io/badge/-NO-red.svg)      | `false`       |
 | `MAX_PAYLOAD_SIZE`       | Maximum payload size in bytes                          | ![](https://img.shields.io/badge/-NO-red.svg)      | `2000000`     |
 | `EJBCA_SEARCH_PAGE_SIZE` | Maximum number of certificates to fetch in one request | ![](https://img.shields.io/badge/-NO-red.svg)      | `100`         |
+| `EJBCA_TIMEOUT_CONNECT`  | Connection timeout in milliseconds for EJBCA SOAP and REST API calls | ![](https://img.shields.io/badge/-NO-red.svg)      | `5000`        |
+| `EJBCA_TIMEOUT_REQUEST`  | Request (read) timeout in milliseconds for EJBCA SOAP and REST API calls | ![](https://img.shields.io/badge/-NO-red.svg)  | `30000`       |
 
 ### Proxy settings
 

--- a/src/main/java/com/czertainly/ca/connector/ejbca/service/impl/AuthorityInstanceServiceImpl.java
+++ b/src/main/java/com/czertainly/ca/connector/ejbca/service/impl/AuthorityInstanceServiceImpl.java
@@ -22,6 +22,7 @@ import com.czertainly.ca.connector.ejbca.ws.EjbcaWS;
 import com.czertainly.ca.connector.ejbca.ws.EjbcaWSService;
 import com.czertainly.core.util.AttributeDefinitionUtils;
 import com.czertainly.core.util.KeyStoreUtils;
+import io.netty.channel.ChannelOption;
 import io.netty.handler.ssl.SslContext;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
@@ -46,6 +47,7 @@ import jakarta.xml.ws.BindingProvider;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.SecureRandom;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -67,10 +69,10 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceService {
     private static final Map<Long, EjbcaWS> connectionsCache = new ConcurrentHashMap<>();
     private static final Map<Long, WebClient> connectionsRestApiCache = new ConcurrentHashMap<>();
 
-    @Value("${ejbca.timeout.connect:500}")
+    @Value("${ejbca.timeout.connect:5000}")
     private int connectionTimeout;
 
-    @Value("${ejbca.timeout.request:1500}")
+    @Value("${ejbca.timeout.request:30000}")
     private int requestTimeout;
 
     @Autowired
@@ -225,13 +227,34 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceService {
         EjbcaWS port = service.getEjbcaWSPort();
         final Map<String, Object> requestContext = ((BindingProvider) port).getRequestContext();
         requestContext.put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, instance.getUrl());
-        requestContext.put(ApplicationConfig.CONNECT_TIMEOUT, connectionTimeout);
-        requestContext.put(ApplicationConfig.REQUEST_TIMEOUT, 1500);
+        applyTimeouts(requestContext);
         requestContext.put(ApplicationConfig.REQUEST_SSL_SOCKET_FACTORY, createSSLSocketFactory(instance));
 
         logger.info("Connected to EJBCA {}", port.getEjbcaVersion());
 
         return port;
+    }
+
+    /**
+     * Applies the configured connect and request (read) timeouts to the JAX-WS request context.
+     * The request timeout is driven by {@code ejbca.timeout.request}; it was previously hardcoded,
+     * which ignored the configured value and caused SocketTimeoutException ("Read timed out") once
+     * an EJBCA SOAP call took longer than the fixed limit.
+     */
+    void applyTimeouts(Map<String, Object> requestContext) {
+        requestContext.put(ApplicationConfig.CONNECT_TIMEOUT, connectionTimeout);
+        requestContext.put(ApplicationConfig.REQUEST_TIMEOUT, requestTimeout);
+    }
+
+    /**
+     * Applies the configured connect and response (read) timeouts to the reactor-netty HTTP client
+     * used for EJBCA REST calls. The client previously had no read timeout, so an unresponsive REST
+     * endpoint could hang the call indefinitely.
+     */
+    HttpClient withTimeouts(HttpClient httpClient) {
+        return httpClient
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectionTimeout)
+                .responseTimeout(Duration.ofMillis(requestTimeout));
     }
 
     private SSLSocketFactory createSSLSocketFactory(AuthorityInstance instance) {
@@ -330,7 +353,7 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceService {
 
         SslContext sslContext = EjbcaRestApiClient.createSslContext(attributes, trustedCertificatesConfig.getDefaultTrustManagers());
 
-        HttpClient httpClient = HttpClient.create().secure(t -> t.sslContext(sslContext));
+        HttpClient httpClient = withTimeouts(HttpClient.create()).secure(t -> t.sslContext(sslContext));
 
         return WebClient
                 .builder()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,8 +22,8 @@ spring:
 
 ejbca:
   timeout:
-    connect: 500
-    request: 1500
+    connect: ${EJBCA_TIMEOUT_CONNECT:5000}
+    request: ${EJBCA_TIMEOUT_REQUEST:30000}
   search:
     # The maximum number of certificates to return in one page
     pageSize: ${EJBCA_SEARCH_PAGE_SIZE:100}

--- a/src/test/java/com/czertainly/ca/connector/ejbca/service/impl/AuthorityInstanceServiceImplTest.java
+++ b/src/test/java/com/czertainly/ca/connector/ejbca/service/impl/AuthorityInstanceServiceImplTest.java
@@ -1,0 +1,42 @@
+package com.czertainly.ca.connector.ejbca.service.impl;
+
+import com.czertainly.ca.connector.ejbca.config.ApplicationConfig;
+import io.netty.channel.ChannelOption;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AuthorityInstanceServiceImplTest {
+
+    // Values distinct from the production defaults (5000/30000) so the tests fail if the code
+    // ever reverts to hardcoding instead of reading the injected fields.
+    private AuthorityInstanceServiceImpl serviceWithTimeouts() {
+        AuthorityInstanceServiceImpl service = new AuthorityInstanceServiceImpl();
+        ReflectionTestUtils.setField(service, "connectionTimeout", 1234);
+        ReflectionTestUtils.setField(service, "requestTimeout", 5678);
+        return service;
+    }
+
+    @Test
+    void applyTimeouts_usesConfiguredConnectAndRequestTimeouts() {
+        Map<String, Object> requestContext = new HashMap<>();
+        serviceWithTimeouts().applyTimeouts(requestContext);
+
+        assertEquals(1234, requestContext.get(ApplicationConfig.CONNECT_TIMEOUT));
+        assertEquals(5678, requestContext.get(ApplicationConfig.REQUEST_TIMEOUT));
+    }
+
+    @Test
+    void withTimeouts_appliesConfiguredConnectAndResponseTimeoutsToHttpClient() {
+        HttpClient client = serviceWithTimeouts().withTimeouts(HttpClient.create());
+
+        assertEquals(Duration.ofMillis(5678), client.configuration().responseTimeout());
+        assertEquals(1234, client.configuration().options().get(ChannelOption.CONNECT_TIMEOUT_MILLIS));
+    }
+}


### PR DESCRIPTION
- Apply the configured `ejbca.timeout.request` to the JAX-WS SOAP read timeout (it was hardcoded to 1500 ms, ignoring the property and causing `SocketTimeoutException: Read timed out`).
- Apply the same connect and response timeouts to the EJBCA REST client (`WebClient`/reactor-netty), which previously had no read timeout.
- Raise default timeouts to connect 5000 ms and request 30000 ms, and make both overridable via `EJBCA_TIMEOUT_CONNECT` / `EJBCA_TIMEOUT_REQUEST`.
- Document `EJBCA_TIMEOUT_CONNECT` and `EJBCA_TIMEOUT_REQUEST` in the README.
- Extract `applyTimeouts(...)` and add a unit test asserting both timeouts come from the configured fields.
