### PR TITLE
Update actions/cache to v6.0.0 and pin codeql-action comment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,13 +21,13 @@ jobs:
           java-version: 21
           distribution: 'temurin'
       - name: Cache SonarQube packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -23,7 +23,7 @@ jobs:
           java-version: 21
           distribution: 'temurin'
       - name: Cache Maven packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -96,6 +96,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary

Bump `actions/cache` to its new major **v6.0.0** (SHA-pinned) and make the `github/codeql-action` inline comment precise. All other actions in the workflows are already SHA-pinned to the latest release within their major.

## Changes

| Action | Previous | Updated to | Change |
|---|---|---|---|
| `actions/cache` | `27d5ce…fccae # v5.0.5` | `2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0` | Major update (build.yml, build_pr.yml) |
| `github/codeql-action` | `8aad20d…d87c1e # v4` | `8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2` | Comment tidy — SHA unchanged, already v4.36.2 |

## v6 compatibility

`actions/cache` v6.0.0 is an internal change only (toolkit dep bump + ESM source migration). The `action.yml` inputs/outputs are identical to v5.0.5 and the runtime stays `node24`. The earlier breaking changes — the cache service v2 rewrite (v4.2.0, backward compatible) and the node24/runner ≥ 2.327.1 requirement (v5.0.0) — are both already satisfied by the current v5.0.5 pin and GitHub-hosted `ubuntu-latest` runners. No usage here is affected.

## Untouched

The two Docker workflows call first-party reusable workflows (`OmniTrustILM/.github/...@main`), which are intentionally tracked by branch rather than SHA-pinned.

**Files modified**: 3 (`build.yml`, `build_pr.yml`, `codeql.yml`)
**Already up to date**: `actions/checkout`, `actions/setup-java`, `actions/upload-artifact`, `actions/download-artifact`, `octokit/request-action`