### PR TITLE
Add CERT_NOTIFIEDABOUTEXPIRATION to discovery certificate-status options

### DIFF
--- a/src/main/java/com/otilm/ca/connector/ejbca/dto/ejbca/request/SearchCertificateCriteriaRestRequest.java
+++ b/src/main/java/com/otilm/ca/connector/ejbca/dto/ejbca/request/SearchCertificateCriteriaRestRequest.java
@@ -134,6 +134,7 @@ public class SearchCertificateCriteriaRestRequest {
      */
     public enum CertificateStatus {
         CERT_ACTIVE,
+        CERT_NOTIFIEDABOUTEXPIRATION,
         CERT_REVOKED,
         REVOCATION_REASON_UNSPECIFIED,
         REVOCATION_REASON_KEYCOMPROMISE,

--- a/src/test/java/com/otilm/ca/connector/ejbca/service/impl/DiscoveryAttributeServiceImplTest.java
+++ b/src/test/java/com/otilm/ca/connector/ejbca/service/impl/DiscoveryAttributeServiceImplTest.java
@@ -26,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -289,6 +290,47 @@ class DiscoveryAttributeServiceImplTest {
         // status content must contain all CertificateStatus enum values
         int expectedStatusCount = SearchCertificateCriteriaRestRequest.CertificateStatus.values().length;
         assertEquals(expectedStatusCount, statusData.getContent().size());
+    }
+
+    @Test
+    void getInstanceAndKindAttributes_ejbca_statusContentMatchesEjbcaSearchStatuses() {
+        // Source of truth: the complete set of STATUS values accepted by EJBCA's REST
+        // certificate-search API (SearchCertificateCriteriaRestRequest.CertificateStatus),
+        // stable across every EJBCA version the connector supports (7.8+).
+        // Hardcoded on purpose so this test is independent of the connector's own enum and
+        // catches drift in BOTH directions:
+        //   - a missing status silently skips those certificates during discovery (issue #120,
+        //     which dropped CERT_NOTIFIEDABOUTEXPIRATION);
+        //   - a bogus/extra status makes EJBCA reject the whole search request with HTTP 400.
+        Set<String> expected = Set.of(
+                "CERT_ACTIVE",
+                "CERT_NOTIFIEDABOUTEXPIRATION",
+                "CERT_REVOKED",
+                "REVOCATION_REASON_UNSPECIFIED",
+                "REVOCATION_REASON_KEYCOMPROMISE",
+                "REVOCATION_REASON_CACOMPROMISE",
+                "REVOCATION_REASON_AFFILIATIONCHANGED",
+                "REVOCATION_REASON_SUPERSEDED",
+                "REVOCATION_REASON_CESSATIONOFOPERATION",
+                "REVOCATION_REASON_CERTIFICATEHOLD",
+                "REVOCATION_REASON_REMOVEFROMCRL",
+                "REVOCATION_REASON_PRIVILEGESWITHDRAWN",
+                "REVOCATION_REASON_AACOMPROMISE"
+        );
+
+        List<BaseAttribute> attrs = service.getInstanceAndKindAttributes(
+                DiscoveryKind.EJBCA.name(), List.of(), List.of(), List.of());
+
+        DataAttributeV2 statusData = (DataAttributeV2) attrs.get(3);
+        List<String> offered = statusData.getContent().stream()
+                .map(c -> (String) c.getData())
+                .toList();
+
+        // No duplicates in the offered options.
+        assertEquals(offered.size(), Set.copyOf(offered).size(),
+                "status options must not contain duplicates: " + offered);
+        // Exactly the EJBCA-accepted set — nothing missing, nothing extra.
+        assertEquals(expected, Set.copyOf(offered));
     }
 
     @Test

--- a/src/test/java/com/otilm/ca/connector/ejbca/service/impl/DiscoveryAttributeServiceImplTest.java
+++ b/src/test/java/com/otilm/ca/connector/ejbca/service/impl/DiscoveryAttributeServiceImplTest.java
@@ -294,14 +294,13 @@ class DiscoveryAttributeServiceImplTest {
 
     @Test
     void getInstanceAndKindAttributes_ejbca_statusContentMatchesEjbcaSearchStatuses() {
-        // Source of truth: the complete set of STATUS values accepted by EJBCA's REST
-        // certificate-search API (SearchCertificateCriteriaRestRequest.CertificateStatus),
-        // stable across every EJBCA version the connector supports (7.8+).
-        // Hardcoded on purpose so this test is independent of the connector's own enum and
-        // catches drift in BOTH directions:
-        //   - a missing status silently skips those certificates during discovery (issue #120,
-        //     which dropped CERT_NOTIFIEDABOUTEXPIRATION);
-        //   - a bogus/extra status makes EJBCA reject the whole search request with HTTP 400.
+        // The discovery "Certificate status" options must match exactly the status values that
+        // EJBCA's REST certificate-search API accepts, a set that is stable across every EJBCA
+        // version the connector supports from 7.8 onward. The expected values are written out
+        // explicitly here, rather than derived from the connector enum, so the test stays an
+        // independent source of truth and catches drift either way: a status missing from the
+        // options silently skips those certificates during discovery, as in issue 120; an
+        // unsupported status makes EJBCA reject the whole search request with HTTP 400.
         Set<String> expected = Set.of(
                 "CERT_ACTIVE",
                 "CERT_NOTIFIEDABOUTEXPIRATION",
@@ -321,7 +320,10 @@ class DiscoveryAttributeServiceImplTest {
         List<BaseAttribute> attrs = service.getInstanceAndKindAttributes(
                 DiscoveryKind.EJBCA.name(), List.of(), List.of(), List.of());
 
-        DataAttributeV2 statusData = (DataAttributeV2) attrs.get(3);
+        DataAttributeV2 statusData = (DataAttributeV2) attrs.stream()
+                .filter(a -> DiscoveryAttributeServiceImpl.ATTRIBUTE_EJBCA_STATUS.equals(a.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("status attribute not found"));
         List<String> offered = statusData.getContent().stream()
                 .map(c -> (String) c.getData())
                 .toList();

--- a/src/test/java/com/otilm/ca/connector/ejbca/service/impl/DiscoveryAttributeServiceImplTest.java
+++ b/src/test/java/com/otilm/ca/connector/ejbca/service/impl/DiscoveryAttributeServiceImplTest.java
@@ -296,11 +296,7 @@ class DiscoveryAttributeServiceImplTest {
     void getInstanceAndKindAttributes_ejbca_statusContentMatchesEjbcaSearchStatuses() {
         // The discovery "Certificate status" options must match exactly the status values that
         // EJBCA's REST certificate-search API accepts, a set that is stable across every EJBCA
-        // version the connector supports from 7.8 onward. The expected values are written out
-        // explicitly here, rather than derived from the connector enum, so the test stays an
-        // independent source of truth and catches drift either way: a status missing from the
-        // options silently skips those certificates during discovery, as in issue 120; an
-        // unsupported status makes EJBCA reject the whole search request with HTTP 400.
+        // version the connector supports from 7.8 onward.
         Set<String> expected = Set.of(
                 "CERT_ACTIVE",
                 "CERT_NOTIFIEDABOUTEXPIRATION",
@@ -329,7 +325,7 @@ class DiscoveryAttributeServiceImplTest {
                 .toList();
 
         // No duplicates in the offered options.
-        assertEquals(offered.size(), Set.copyOf(offered).size(),
+        assertEquals(Set.copyOf(offered).size(), offered.size(),
                 "status options must not contain duplicates: " + offered);
         // Exactly the EJBCA-accepted set — nothing missing, nothing extra.
         assertEquals(expected, Set.copyOf(offered));


### PR DESCRIPTION
## Summary

Discovery's **Certificate status** options are built from the connector's `CertificateStatus` enum, which mirrors EJBCA's REST certificate-search statuses but was missing `CERT_NOTIFIEDABOUTEXPIRATION` — the status EJBCA assigns to certificates that are still active but for which an upcoming-expiry notification has been sent.

Because that status was never offered, it could never be selected, so discovery (which turns each selected status into an `EQUAL STATUS=…` search criterion) silently skipped those certificates. Clearing all status values removes the `STATUS` filter entirely, which is exactly why a no-filter run returned far more certificates than the defaults — the gap was the `CERT_NOTIFIEDABOUTEXPIRATION` certs.

Fixes #120.

## Change

- Add `CERT_NOTIFIEDABOUTEXPIRATION` to `SearchCertificateCriteriaRestRequest.CertificateStatus`, in the same position as EJBCA upstream (between `CERT_ACTIVE` and `CERT_REVOKED`). The discovery options derive from `values()`, so it is now offered and selected by default. It is correctly **not** added to `revocationReasons()`.

## Backward compatibility

`CERT_NOTIFIEDABOUTEXPIRATION` has been part of EJBCA's REST search `CertificateStatus` enum — and validated via `resolveCertificateStatusByName` — since at least **EJBCA 7.8.0**, the connector's minimum supported version (verified against the 7.8 / 7.9 / 7.10 / 7.11 / 8.0 / 9.0 tags). The connector's v1/v2 search split (`resolveSearchVersion`) differs only in pagination, not in the status criteria format. So sending this value is accepted by every supported EJBCA version and cannot trigger a `400`.

## Tests

- Added a contract test that pins the offered statuses to EJBCA's canonical set, hardcoded independently of the connector enum, so drift is caught in **both** directions (a missing status that skips certs, or a bogus status that EJBCA would reject).
- Verified the test fails when the fix is reverted (reproduces #120) and passes with it. Full suite: 270/270 green.
