### PR TITLE
Update parent, dependencies, and GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,22 +12,22 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: 21
           distribution: 'temurin'
       - name: Cache SonarQube packages
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -14,16 +14,16 @@ jobs:
       packages: read
       security-events: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: 21
           distribution: 'temurin'
       - name: Cache Maven packages
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -96,6 +96,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -42,7 +42,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Checkout the PR branch
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ FROM eclipse-temurin:21-jre-alpine
 
 LABEL org.opencontainers.image.authors="ILM <ilm@omnitrust.com>"
 
+# apply outstanding Alpine security updates on top of the base image
+RUN apk --no-cache upgrade
+
 # add non root user ejbca-ng-connector
 RUN addgroup --system --gid 10001 ejbca-ng-connector && adduser --system --home /opt/ejbca-ng-connector --uid 10001 --ingroup ejbca-ng-connector ejbca-ng-connector
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.otilm</groupId>
         <artifactId>dependencies</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>ejbca-ng-connector</artifactId>
@@ -48,10 +48,6 @@
             src/main/java/com/otilm/ca/connector/ejbca/ws/**,
             src/main/java/db/migration/**
         </sonar.exclusions>
-        <!-- CVE overrides: pin transitive deps to patched versions -->
-        <tomcat.version>10.1.55</tomcat.version>
-        <netty.version>4.1.135.Final</netty.version>
-        <postgresql.version>42.7.11</postgresql.version>
     </properties>
 
     <dependencies>
@@ -69,17 +65,14 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.26.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.26.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
-            <version>2.26.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary

Bump the parent POM to the current `com.otilm:dependencies` SNAPSHOT, remove three local CVE overrides that the new parent makes redundant or harmful, refresh the GitHub Actions pins, and clear the outstanding Alpine advisories in the runtime image.

> **Merge order:** this PR depends on OmniTrustILM/dependencies#137 and must merge after it. See the log4j section below.

## Parent and the local CVE overrides

Parent `com.otilm:dependencies` `1.4.1` → `1.4.2-SNAPSHOT`, which moves the managed set to Spring Boot 3.5.16.

All three overrides in `<properties>` are removed. One was redundant; the other two had quietly become **downgrades** against the newer parent, and keeping them would have re-opened advisories the parent already closes:

| Override | Local pin | Parent 1.4.2-SNAPSHOT | Effect if kept |
|---|---|---|---|
| `tomcat.version` | 10.1.55 | 10.1.55 | Redundant — no change in resolved version |
| `netty.version` | 4.1.135.Final | **4.1.136.Final** | Downgrade — re-opens CVE-2026-59901 and CVE-2026-55831 / CVE-2026-55833 / CVE-2026-56745 |
| `postgresql.version` | 42.7.11 | **42.7.12** | Downgrade — re-opens CVE-2026-54291 |

Resolved tree after removal: `tomcat-embed-core:10.1.55`, `netty-*:4.1.136.Final`, `postgresql:42.7.12`, and `jackson-databind:2.22.1` from the parent's pin.

## log4j

The three hand-pinned versions on `log4j-core`, `log4j-api`, and `log4j-1.2-api` are removed and inherited instead.

Pinning artifacts individually only ever covered the ones named. `log4j-to-slf4j`, which arrives transitively through `spring-boot-starter-logging`, was left on Spring Boot's managed **2.24.3** while the three named artifacts sat at 2.26.0 — a split log4j2 classpath.

The root cause was in the parent: it set `<log4j.version>`, but Spring Boot's managed log4j2 artifacts read `<log4j2.version>`, so the parent's value never applied. OmniTrustILM/dependencies#137 fixes the property name and backs it with a `log4j-bom` import at 2.26.1.

With that parent change in place and no log4j configuration left in this POM, the whole set resolves consistently:

```
org.apache.logging.log4j:log4j-core:jar:2.26.1
org.apache.logging.log4j:log4j-api:jar:2.26.1
org.apache.logging.log4j:log4j-1.2-api:jar:2.26.1
org.apache.logging.log4j:log4j-to-slf4j:jar:2.26.1
```

Merging this PR before the parent one would resolve log4j2 to 2.24.3, which is why the ordering above matters.

## Dependencies left unchanged

- `com.otilm:interfaces` stays at `2.18.1-SNAPSHOT` — already the current `main` version.
- `com.keyfactor:x509-common-util` stays at 3.2.0. It is not published to any public Maven repository and ships as a jar under `ejbca-libs/`, so there is no upstream version to move to.
- `net.steppschuh.markdowngenerator` stays at 1.3.1.1, which is the latest release.

## GitHub Actions

All actions remain pinned to full commit SHAs.

| Action | Previous | Updated to |
|---|---|---|
| `actions/checkout` | `9c091b…e3e0 # v7.0.0` | `3d3c42…90b1 # v7.0.1` |
| `actions/setup-java` | `ad2b38…d287 # v5.3.0` | `03ad4d…ac95 # v5.6.0` |
| `actions/cache` | `2c8a9b…a9c8 # v6.0.0` | `55cc83…52a9 # v6.1.0` |
| `github/codeql-action` | `8aad20…7c1e # v4.36.2` | `f205ea…7b38 # v4.37.4` |

Already on the latest release: `actions/upload-artifact` v7.0.1, `actions/download-artifact` v8.0.1, `octokit/request-action` v3.0.0. The `OmniTrustILM/.github` reusable workflows stay on `@main` by convention.

## Container

Added `apk --no-cache upgrade` to the runtime stage. Trivy flags four HIGH OS-package advisories carried by `eclipse-temurin:21-jre-alpine` — CVE-2026-56131 and CVE-2026-56408 (libexpat 2.8.1-r0) and CVE-2026-2100 (p11-kit 0.25.5-r2). Fixed Alpine packages exist, but the base tag has not been rebuilt since 2026-06-22. The trade-off is that package contents now depend on build date as well as the base tag.

The build stage is already on `maven:3.9.16-eclipse-temurin-21`, the current 3.9.x tag. The runtime stage stays on Temurin 21 to match the Java target.

## Superseded

Bot PRs to close once this merges: #129, #132, #133, #134, #135.

#136 (`Sync repo to org template`) also touches the workflow files; expect a conflict depending on merge order.